### PR TITLE
Compability with Ubuntu20.04 + ROS Noetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
             DOCKER_IMAGE : ubuntu:xenial
           - ROS_DISTRO : melodic
             DOCKER_IMAGE : ubuntu:bionic
+          - ROS_DISTRO : noetic
+            DOCKER_IMAGE : ubuntu:focal
     steps:
       - name: Setup OS
         run: |

--- a/.travis.sh
+++ b/.travis.sh
@@ -9,12 +9,28 @@ echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
 sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros-latest.list"
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 sudo apt-get update -qq
-sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-catkin-tools python-wstool ros-${ROS_DISTRO}-catkin
 
+
+# Install ROS
+if [[ "$ROS_DISTRO" ==  "noetic" ]]; then
+    sudo apt-get install -y -q python3-catkin-pkg python3-catkin-tools python3-rosdep python3-wstool python3-rosinstall-generator python3-osrf-pycommon
+else
+    sudo apt-get install -y -q python-catkin-pkg python-catkin-tools python-rosdep python-wstool python-rosinstall-generator
+fi
+sudo apt-get install -y -q ros-$ROS_DISTRO-catkin
 source /opt/ros/${ROS_DISTRO}/setup.bash
+
+# Setup for rosdep
 sudo rosdep init
+# use snapshot of rosdep list
+    # https://github.com/ros/rosdistro/pull/31570#issuecomment-1000497517
+if [[ "$ROS_DISTRO" = "kinetic" ]]; then
+    sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
+    sudo wget https://gist.githubusercontent.com/cottsay/b27a46e53b8f7453bf9ff637d32ea283/raw/476b3714bb90cfbc6b8b9d068162fc6408fa7f76/30-xenial.list -O /etc/ros/rosdep/sources.list.d/30-xenial.list
+fi
 rosdep update --include-eol-distros
 
+# Install source code
 (cd ${CI_SOURCE_PATH}; git log --oneline | head -10)
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-apt-get update -qq && apt-get install -y -q wget sudo lsb-release gnupg git sed # for docker
+apt-get update -qq && apt-get install -y -q wget sudo lsb-release gnupg git sed build-essential # for docker
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
@@ -31,7 +31,6 @@ fi
 rosdep update --include-eol-distros
 
 # Install source code
-(cd ${CI_SOURCE_PATH}; git log --oneline | head -10)
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws
 ln -sf ${CI_SOURCE_PATH} src/${REPOSITORY_NAME}

--- a/cfs_sensor/CMakeLists.txt
+++ b/cfs_sensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(cfs_sensor)
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs )

--- a/leddar_one/CMakeLists.txt
+++ b/leddar_one/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(leddar_one)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/leddar_one/src/leddar_one_driver.cpp
+++ b/leddar_one/src/leddar_one_driver.cpp
@@ -73,7 +73,7 @@ LeddarOne::~LeddarOne()
 
 void LeddarOne::communicationFunc()
 {
-  double du = 1 / loop_rate_ * 1000; // to millisec
+  int du = 1.0 / loop_rate_ * 1000; // to millisec
 
   uint16_t tab_reg_values[32];
   while(ros::ok())

--- a/lepton_thermal_sensor/CMakeLists.txt
+++ b/lepton_thermal_sensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(lepton_thermal_sensor)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")

--- a/px4flow_node/CMakeLists.txt
+++ b/px4flow_node/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(px4flow_node)
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs geometry_msgs sensor_msgs image_transport)
-find_package(Boost REQUIRED COMPONENTS thread system signals)
+find_package(Boost REQUIRED COMPONENTS thread system)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/sensor_interface/CMakeLists.txt
+++ b/sensor_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sensor_interface)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/takasako_sps/CMakeLists.txt
+++ b/takasako_sps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(takasako_sps)
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
Update files to be compatible with Ubuntu20.04 + ROS Noetic

- CMakeLists.txt: update the version from 2.8.3 to 3.0.2
- Correct the type of variables `boost::posix_time::milliseconds`: `double` -> `int`